### PR TITLE
fix: Require() function fail and lifestyle order (closes #2 and #3)

### DIFF
--- a/RuntimeLibrary/Yum4GodotAPI/YumLuaNode.cs
+++ b/RuntimeLibrary/Yum4GodotAPI/YumLuaNode.cs
@@ -60,7 +60,7 @@ public partial class YumLuaNode : Node
   [ExportGroup("Runtime Configuration")]
   [Export] private Vector3I MinimumVersion = new(1, 7, 0);
   [Export] private Vector3I MaximumVersion = new(2, 0, 0);
-  [Export] private Vector3I RecommendedVersion = new(1, 6, 0);
+  [Export] private Vector3I RecommendedVersion = new(1, 7, 0);
   [Export] private Godot.Collections.Array<Vector3I> ExcludedVersions = [new(1, 5, 0)];
   [Export] private bool PrintErrors = true;
   [Export] private bool PrintWarnings = true;
@@ -79,11 +79,11 @@ public partial class YumLuaNode : Node
     return base.Call(name, args);
   }
 
-  public override void _Ready()
+  private void SetUp()
   {
     if (!YumEngineRuntimeInfo.Require(MinimumVersion, MaximumVersion, [.. ExcludedVersions]))
     {
-      GD.PushWarning(
+      GD.PushError(
         new NotSupportedException(
           $"Current version: {YumEngineRuntimeInfo.VersionString()}, required (at least): {MinimumVersion}, recommended: {RecommendedVersion}"
         )
@@ -139,12 +139,17 @@ public partial class YumLuaNode : Node
 
     var uidOfThis = InternalLuaState.GetUID();
     NodeHandles[uidOfThis] = this;
+    localLuaState.Load($"{ClassName}:set({uidOfThis})");
+  }
 
-    localLuaState.Load($"{ClassName}:set({uidOfThis})\n{ClassName}:_ready()");
+  public override void _Ready()
+  {
+    localLuaState.Load($"{ClassName}:_ready()");
   }
 
   public override void _EnterTree()
   {
+    SetUp();
     localLuaState.Load($"{ClassName}:_enter_tree()");
   }
 

--- a/RuntimeLibrary/YumEngineAPI/Yum.cs
+++ b/RuntimeLibrary/YumEngineAPI/Yum.cs
@@ -13,31 +13,28 @@ namespace Yum4Godot.RuntimeLibrary.YumEngineAPI
     public static int Minor() => Native.YumEngineInfo_versionMinor();
     public static int Patch() => Native.YumEngineInfo_versionPatch();
 
-    public static bool RequireMin(int maj, int min, int patch)
+    private static int CompareVersion(int aMaj, int aMin, int aPatch, int bMaj, int bMin, int bPatch)
     {
-      var current = (Major(), Minor(), Patch());
-      var required = (maj, min, patch);
-      return current.CompareTo(required) >= 0;
+      if (aMaj != bMaj) return aMaj.CompareTo(bMaj);
+      if (aMin != bMin) return aMin.CompareTo(bMin);
+      return aPatch.CompareTo(bPatch);
     }
 
-    public static bool RequireMin(Godot.Vector3I v)
+    public static bool RequireMin(int maj, int min, int patch)
     {
-      return RequireMin(v.X, v.Y, v.Z);
+      var cmp = CompareVersion(Major(), Minor(), Patch(), maj, min, patch);
+      return cmp >= 0;
     }
+
+    public static bool RequireMin(Godot.Vector3I v) => RequireMin(v.X, v.Y, v.Z);
 
     public static bool RequireMax(int maj, int min, int patch)
     {
-      if (maj < Major()) return false;
-      if (min < Minor()) return false;
-      if (patch < Patch()) return false;
-
-      return true;
+      var cmp = CompareVersion(Major(), Minor(), Patch(), maj, min, patch);
+      return cmp <= 0;
     }
 
-    public static bool RequireMax(Godot.Vector3I v)
-    {
-      return RequireMax(v.X, v.Y, v.Z);
-    }
+    public static bool RequireMax(Godot.Vector3I v) => RequireMax(v.X, v.Y, v.Z);
 
     public static bool IsSameVersion(Godot.Vector3I v)
     {
@@ -48,7 +45,12 @@ namespace Yum4Godot.RuntimeLibrary.YumEngineAPI
     {
       if (!RequireMin(min)) return false;
       if (!RequireMax(max)) return false;
-      foreach (var exclude in excludes) if (IsSameVersion(exclude)) return false;
+
+      if (excludes != null)
+      {
+        foreach (var exclude in excludes)
+          if (IsSameVersion(exclude)) return false;
+      }
 
       return true;
     }


### PR DESCRIPTION
- Require() function will return `true` or `false` correctly.
- C# callbacks are now injected in `Godot.Node._EnterTree()` instead of `Godot.Node._Ready()`
- `Godot.Node._Notification(int what)` function removed. Can be included back in further versions.